### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
 
     "require": {
-        "defuse/php-encryption": "2.0.x-dev@dev"
+        "defuse/php-encryption": "2.0.x"
     },
 
     "extra": {


### PR DESCRIPTION
defuse/php-encryption package version 2.0.x-dev@dev was not found, so I changed it to just 2.0.x. Is this good?
