### PR TITLE
Fix notice during /dev/build when EncryotedDataObjectFieldsExtension-…

### DIFF
--- a/code/extensions/EncryptDataObjectFieldsExtension.php
+++ b/code/extensions/EncryptDataObjectFieldsExtension.php
@@ -81,7 +81,7 @@ class EncryptDataObjectFieldsExtension extends DataExtension
     {
         $methods = array();
         $classes = Config::inst()->get('EncryptDataObjectFieldsExtension', 'EncryptedDataObjects');
-        if (in_array($this->owner->ClassName, $classes)) {
+        if (is_object($this->owner) && in_array($this->owner->ClassName, $classes)) {
             $fields = Config::inst()->get($this->owner->ClassName, 'db', Config::UNINHERITED);
             foreach ($fields as $fieldName => $fieldType) {
                 $reflector = Object::create_from_string($fieldType, '')->is_encrypted;


### PR DESCRIPTION
…>owner is not defined

Running /dev/build?flush=all in SilverStripe 3.1.18 raised the following notice: "[Notice] Trying to get property of non-object", relating to $this->owner->ClassName on line 84.

I do not know how the allMethodNames() method is used by SilverStripe, but this seems to fix the notice.
