### PR TITLE
Make it possible to define DataObject specific encryption keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,28 @@ In your DataObject, use EncryptedDBField, to have it encrypted. At this point, e
 Set a key in your `_ss_environment` file. 
  
  ```define('ENCRYPT_AT_REST_KEY', 'mysupersecretlonghexkeyhere1234567890');```
+ 
+### DataObject specific encryption keys
+ 
+Another, optional and advanced way to define the key is to create an optional method in your DataObject class:
+ 
+```PHP
+class MyDataObject extends DataObject
+{
+    private static $db = array(
+        'MyEncryptedField' => 'EncryptedText'
+    );
+    
+    public function provideEncryptionKey($field_name, $field_type)
+    {
+        return *A custom key here*;
+    }
+}
+```
 
+This way you can have multiple keys and you are able to decide which key to use in which situation. You are allowed to return either a Defuse\Crypto\Key object or a plain string presentation of the key. You can also return just `null`, if you want to stick with the default key defined in the `ENCRYPT_AT_REST_KEY` constant. The latter is also used if you do not create the `provideEncryptionKey()` method at all.
+ 
+ `$field_name` and `$field_type` arguments can be used to get to know which field is being currently encrypted/decrypted. The latter argument tells the data type class of the field, for example `EncryptedText`.
 
 
 

--- a/code/fieldtypes/EncryptedDatetime.php
+++ b/code/fieldtypes/EncryptedDatetime.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once 'EncryptedFieldTrait.php'; //Traits are not auto-loaded by SilverStripe
 
 /**
  * Class EncryptedDatetime
@@ -10,7 +11,8 @@
  */
 class EncryptedDatetime extends SS_Datetime
 {
-
+    use EncryptedFieldTrait;
+    
     public $is_encrypted = true;
     /**
      * @var AtRestCryptoService
@@ -25,6 +27,7 @@ class EncryptedDatetime extends SS_Datetime
 
     public function setValue($value, $record = array())
     {
+    	$this->setEncryptionKeyFromRecord($record);
         if (array_key_exists($this->name, $record) && $value === null) {
             $this->value = $record[$this->name];
         } else {
@@ -36,7 +39,7 @@ class EncryptedDatetime extends SS_Datetime
     {
         // Test if we're actually an encrypted value;
         if (ctype_xdigit($value) && strlen($value) > 130) {
-            return $this->service->decrypt($value);
+            return $this->service->decrypt($value, $this->getEncryptionKey());
         }
         return $value;
     }
@@ -65,7 +68,7 @@ class EncryptedDatetime extends SS_Datetime
     public function prepValueForDB($value)
     {
         $value = parent::prepValueForDB($value);
-        $ciphertext = $this->service->encrypt($value);
+        $ciphertext = $this->service->encrypt($value, $this->getEncryptionKey());
         $this->value = $ciphertext;
         return $ciphertext;
     }

--- a/code/fieldtypes/EncryptedEnum.php
+++ b/code/fieldtypes/EncryptedEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once 'EncryptedFieldTrait.php'; //Traits are not auto-loaded by SilverStripe
+
 /**
  * Class EncryptedEnum
  * @package EncryptAtRest\Fieldtypes
@@ -9,7 +11,8 @@
  */
 class EncryptedEnum extends Enum
 {
-
+    use EncryptedFieldTrait;
+    
     public $is_encrypted = true;
     /**
      * @var AtRestCryptoService
@@ -24,6 +27,7 @@ class EncryptedEnum extends Enum
 
     public function setValue($value, $record = array())
     {
+    	   $this->setEncryptionKeyFromRecord($record);
         if (array_key_exists($this->name, $record) && $value === null) {
             $this->value = $record[$this->name];
         } else {
@@ -36,7 +40,7 @@ class EncryptedEnum extends Enum
         // Test if we're actually an encrypted value;
         if (ctype_xdigit($value) && strlen($value) > 130) {
             try {
-                return $this->service->decrypt($value);
+                return $this->service->decrypt($value, $this->getEncryptionKey());
             } catch (Exception $e) {
                 // We were unable to decrypt. Possibly a false positive, but return the unencrypted value
                 return $value;
@@ -69,7 +73,7 @@ class EncryptedEnum extends Enum
     public function prepValueForDB($value)
     {
         $value = parent::prepValueForDB($value);
-        $ciphertext = $this->service->encrypt($value);
+        $ciphertext = $this->service->encrypt($value, $this->getEncryptionKey());
         $this->value = $ciphertext;
         return $ciphertext;
     }

--- a/code/fieldtypes/EncryptedFieldTrait.php
+++ b/code/fieldtypes/EncryptedFieldTrait.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Trait EncryptedFieldTrait
+ *
+ * This is a trait shared by all EncryptedXXX data field classes. Currently it only contains methods and properties for an ability to define custom encryption keys at DataObject level, but perhaps the trait can be extended to cover all other methods that are currently duplicated in the EncryptedXXX classes.
+ */
+trait EncryptedFieldTrait
+{
+	/**
+	 * @var string|Defuse\Crypto\Key|null An encryption key that will override the global ENCRYPT_AT_REST_KEY key.
+	 * @see self::getEncryptionKey()
+	 */
+	private $encryption_key = null;
+	
+	/**
+	 * Returns a custom key if one is explicitly set for this field. If a key is not set using setEncryptionKey(),
+	 * returns null, which will trigger the AtRestCryptoService to use the default global key set in the ENCRYPT_AT_REST_KEY
+	 * constant.
+	 *
+	 * @return string|Defuse\Crypto\Key|null
+	 */
+	public function getEncryptionKey()
+	{
+		return $this->encryption_key;
+	}
+	
+	/**
+	 * Sets an encryption key that will override the default key defined in the ENCRYPT_AT_REST_KEY constant.
+	 * @see self::getEncryptionKey()
+	 * @param string|Defuse\Crypto\Key|null $encryption_key
+	 */
+	public function setEncryptionKey($encryption_key)
+	{
+		$this->encryption_key = $encryption_key;
+	}
+	
+	/**
+	 * Uses a DataObject or $record array to retrieve a custom encryption/decryption key by calling that DataObject's provideEncryptionKey() method. If the method is not defined, does not alter the key which will be used.
+	 *
+	 * @param array|DataObject $record
+	 */
+	private function setEncryptionKeyFromRecord($record)
+	{
+		if (is_object($record))
+		{
+			$data_object = $record;
+		}
+		else
+		{
+			//Create a DataObject from a $record array
+			if (empty($record) || !isset($record['ClassName']) || !isset($record['ID'])) return;
+			$class = $record['ClassName'];
+			if ($id = $record['ID'])
+			{
+				//Use the specific DataObject instance to provide the key
+				$data_object = DataObject::get_by_id($class, $id);
+			}
+			else
+			{
+				//No specific DataObject is defined (probably we are working on a new DataObject which is not yet written to the database), so just create a generic instance of it's class as that's the closest we can get.
+				$data_object = singleton($class);
+			}
+		}
+		if ($data_object->hasMethod('provideEncryptionKey'))
+		{
+			//Retrieve a custom key from the DataObject.
+			$this->setEncryptionKey($data_object->provideEncryptionKey($this->getName(), $this->class));
+		}
+		else
+		{
+			//The DataObject does not have a method that would provide the custom key, so do nothing.
+		}
+	}
+}


### PR DESCRIPTION
Hi,

a project of mine requires that each Member can have a different encryption key than what other members use, so I created this new feature which allows actually every DataObject to define a custom key (if needed).

The TLDR guide on how to use this feature is just to create a new method in your `DataObject` class:

```PHP
class MyDataObject extends DataObject
{
    private static $db = array(
        'MyEncryptedField' => 'EncryptedText'
    );
    
    public function provideEncryptionKey($field_name, $field_type)
    {
        return *A custom key here*;
    }
}
```

When you have this method defined, the module now overrides the `ENCRYPT_AT_REST_KEY` key when encrypting or decrypting a value. This allows you to create any kind of advanced logic for which key to use.

I have also updated the readme file to describe how to use this feature. Of course the default behaviour is still to use the constant defined in `_ss_environment.php`.

---

So, last but not least, as this might be a big change to the module and your plans may differ from this, please let me know your opinion about it. If there's anything you would like me to change in this pull request, I would gladly hear it, as it's you module anyway :). Also you can do any changes yourself if you wish.

I have to say that I haven't really had time to test this very much, but at least the little testing that I have done has worked.

P.S. I would be glad to have a look at the couple of issues that are currently open for this module, perhaps I can do something for them. I'll let you know when I have proceeded with that, but unfortunately I can't promise anything.

