### PR TITLE
Update framework dependency to allow <4.0 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
 
     "require": {
-        "silverstripe/framework": "3.4.*",
+        "silverstripe/framework": "^3.4.5",
         "defuse/php-encryption": "2.0.x"
     },
 


### PR DESCRIPTION
Framework dependency seems too restricted. We've updated our project to framework 3.6.1 and this module is working so far. Would be good to get this merged to avoid having another fork :)