### PR TITLE
Upgrade defuse/php-encryption to v2.2.1

### DIFF
--- a/code/AtRestCryptoService.php
+++ b/code/AtRestCryptoService.php
@@ -22,7 +22,7 @@ class AtRestCryptoService
     public function encrypt($raw, $key = null)
     {
         $key = $this->getKey($key);
-        return Crypto::Encrypt($raw, $key);
+        return Crypto::Encrypt((string)$raw, $key);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,12 @@
     },
 
     "require": {
-        "silverstripe/framework": "^3.4.5",
-        "defuse/php-encryption": "2.0.x"
+        "silverstripe/framework": "^3.7",
+        "defuse/php-encryption": "v2.2.1"
     },
 
     "extra": {
         "installer-name": "encryptatrest"
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
The current version of php-encryption is v2.2.1. 
This library is expected to remain stable and supported by its authors with security and bugfixes until at least January 1st, 2021.

https://github.com/defuse/php-encryption/releases/tag/v2.2.1 - Fixes PHP 7 support.