### PR TITLE
Cast the value to decrypt to a string to prevent type-errors

### DIFF
--- a/code/fieldtypes/EncryptedText.php
+++ b/code/fieldtypes/EncryptedText.php
@@ -25,6 +25,8 @@ class EncryptedText extends Text
 
     public function getDecryptedValue($value)
     {
+        // Type hardening for PHP 8.1+
+        $value = (string)$value;
         // Test if we're actually an encrypted value;
         if (ctype_xdigit($value) && strlen($value) > 130) {
             try {


### PR DESCRIPTION
both `strlen` and `ctype_xdigit` are now type-hardened expecting an explicit string. Passing in `null` will throw an error.

Thus, casting it to string to ensure it is a string, makes sure that PHP doesn't throw an error about the passed in value not being a string.

Resolvel #24 