### PR TITLE
Updates for Silverstripe 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module allows Silverstripe CMS ORM data to be encrypted before being stored
 
 
 ## Requirements
-* SilverStripe CMS 4.9
+* SilverStripe CMS 5.0
 
 ## Installation
 Install via Composer:

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "source": "https://github.com/madmatt/silverstripe-encrypt-at-rest"
     },
     "require": {
-        "silverstripe/framework": "^4.9.0",
+        "silverstripe/framework": "^5",
         "defuse/php-encryption": "^2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/AtRestCryptoService.php
+++ b/src/AtRestCryptoService.php
@@ -182,7 +182,7 @@ class AtRestCryptoService
             $fileID = rtrim($filename, '\\/');
         }
 
-        return $adapter->applyPathPrefix($fileID);
+        return $adapter->prefixPath($fileID);
     }
 
 }

--- a/src/Extension/DecryptDataObjectFieldsExtension.php
+++ b/src/Extension/DecryptDataObjectFieldsExtension.php
@@ -26,10 +26,9 @@ class DecryptDataObjectFieldsExtension extends DataExtension
      * if so, we decrypt these and inject them into the object during hydration so that the rest of the application only
      * has to deal with the decrypted values everywhere.
      *
-     * @param $record
      * @return array
      */
-    public function augmentHydrateFields($record)
+    public function augmentHydrateFields()
     {
         // Look at $this->owner to determine if it has any encrypted database fields
         $schema = DataObject::getSchema();

--- a/tests/AtRestCryptoServiceTest.php
+++ b/tests/AtRestCryptoServiceTest.php
@@ -84,7 +84,7 @@ class AtRestCryptoServiceTest extends SapphireTest
             $file->publishFile();
         }
 
-        $oldFilename = $adapter->applyPathPrefix(
+        $oldFilename = $adapter->prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $file->getFilename(),
@@ -102,9 +102,9 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertEquals($originalFilename, $file->getFilename());
 
         if ($visibility === AssetStore::VISIBILITY_PROTECTED) {
-            $this->assertContains('assets/.protected/', $oldFilename);
+            $this->assertStringContainsString('assets/.protected/', $oldFilename);
         } elseif ($visibility === AssetStore::VISIBILITY_PUBLIC) {
-            $this->assertNotContains('assets/.protected/', $oldFilename);
+            $this->assertStringNotContainsString('assets/.protected/', $oldFilename);
         }
 
         /** @var AtRestCryptoService $service */
@@ -114,9 +114,9 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertEquals($originalFilename . '.enc', $encryptedFile->getFilename());
 
         // Confirm the old file has been deleted
-        $this->assertFileNotExists($oldFilename);
+        $this->assertFileDoesNotExist($oldFilename);
 
-        $encryptedFilename = $adapter->applyPathPrefix(
+        $encryptedFilename = $adapter->prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $encryptedFile->getFilename(),
@@ -130,20 +130,21 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertFileExists($encryptedFilename);
 
         if ($visibility === AssetStore::VISIBILITY_PROTECTED) {
-            $this->assertContains('assets/.protected/', $encryptedFilename);
+            $this->assertStringContainsString('assets/.protected/', $encryptedFilename);
         } elseif ($visibility === AssetStore::VISIBILITY_PUBLIC) {
-            $this->assertNotContains('assets/.protected/', $encryptedFilename);
+            $this->assertStringNotContainsString('assets/.protected/', $encryptedFilename);
         }
 
+        $encryptedFileString = $encryptedFile->getString() ?: '';
         // Confirm the new file is encrypted
-        $this->assertFalse(ctype_print($encryptedFile->getString()));
-        $this->assertNotEquals($originalText, $encryptedFile->getString());
+        $this->assertFalse(ctype_print($encryptedFileString));
+        $this->assertNotEquals($originalText, $encryptedFileString);
         $this->assertEquals($originalFilename, $encryptedFile->Name);
         $this->assertEquals($originalFilename . '.enc', $file->getFilename());
 
         // Now decrypt the file back
         $decryptedFile = $service->decryptFile($encryptedFile, null, $visibility);
-        $decryptedFilename = $adapter->applyPathPrefix(
+        $decryptedFilename = $adapter->prefixPath(
             $strategy->buildFileID(
                 new ParsedFileID(
                     $decryptedFile->getFilename(),
@@ -160,16 +161,16 @@ class AtRestCryptoServiceTest extends SapphireTest
         $this->assertEquals($originalFilename, $decryptedFile->getFilename());
 
         if ($visibility === AssetStore::VISIBILITY_PROTECTED) {
-            $this->assertContains('assets/.protected/', $decryptedFilename);
+            $this->assertStringContainsString('assets/.protected/', $decryptedFilename);
         } elseif ($visibility === AssetStore::VISIBILITY_PUBLIC) {
-            $this->assertNotContains('assets/.protected/', $decryptedFilename);
+            $this->assertStringNotContainsString('assets/.protected/', $decryptedFilename);
         }
 
         // Confirm that original text has been decoded properly
         $this->assertEquals($originalText, $decryptedFile->getString());
 
         // Confirm that encrypted file has been deleted
-        $this->assertFileNotExists($encryptedFilename);
+        $this->assertFileDoesNotExist($encryptedFilename);
     }
 
     /**


### PR DESCRIPTION
Includes Unit test changes for PHPUnit 9.6

Note: https://github.com/madmatt/silverstripe-encrypt-at-rest/pull/31 would need to be merged first to ensure proper Silverstripe 4 compatibility